### PR TITLE
Fix intersection

### DIFF
--- a/examples/working/Intersection.agda
+++ b/examples/working/Intersection.agda
@@ -1,0 +1,14 @@
+module Intersection where
+
+postulate A : Set
+postulate C : Set
+postulate c : (a : A) -> C
+
+MA : (x : A) (y : A) -> C
+MA = _
+
+constr1 : (x : A) (y : A) (z : A) -> MA x z == MA y z
+constr1 _ _ _ = refl
+
+constr2 : (x : A) -> MA x x == c x
+constr2 _ = refl

--- a/src/Tog/Unify/Common.hs
+++ b/src/Tog/Unify/Common.hs
@@ -835,8 +835,7 @@ intersectVars els1 els2 = runMaybeT $ mapM (uncurry areVars) $ zip els1 els2
       t1View <- lift $ whnfView t1
       t2View <- lift $ whnfView t2
       case (t1View, t2View) of
-        (App (Var v1) [], App (Var v2) []) ->
-          return $ (v1 /= v2) <$ unVar v1 -- prune different vars
+        (App (Var v1) [], App (Var v2) []) -> return $ (v1 /= v2) <$ unVar v1 -- prune different vars
         (_,               _)               -> mzero
     areVars _ _ =
       mzero

--- a/src/Tog/Unify/Simple.hs
+++ b/src/Tog/Unify/Simple.hs
@@ -268,7 +268,7 @@ checkMetas (ctx, type_, t1, t2) = do
             done [(mvs, Unify loc ctx type_ t1'' t2'')]
   case (blockedT1, blockedT2) of
     (BlockingHead mv els1, BlockingHead mv' els2) | mv == mv' -> do
-      intersectMetaSpine mv els1 els2 >>= \case                                                               
+      intersectMetaSpine mv els1 els2 >>= \case
         Just mvs -> syntacticEqualityOrPostpone mvs
         Nothing  -> done []
     (BlockingHead mv elims, _) -> do

--- a/src/Tog/Unify/Simple.hs
+++ b/src/Tog/Unify/Simple.hs
@@ -268,15 +268,9 @@ checkMetas (ctx, type_, t1, t2) = do
             done [(mvs, Unify loc ctx type_ t1'' t2'')]
   case (blockedT1, blockedT2) of
     (BlockingHead mv els1, BlockingHead mv' els2) | mv == mv' -> do
-      mbKills <- intersectVars els1 els2
-      case mbKills of
-        Nothing -> do
-          syntacticEqualityOrPostpone $ HS.singleton mv
-        Just kills -> do
-          mvType <- getMetaType mv
-          newMv <- addMeta mvType
-          instantiateMeta mv =<< killArgs newMv kills
-          done []
+      intersectMetaSpine mv els1 els2 >>= \case                                                               
+        Just mvs -> syntacticEqualityOrPostpone mvs
+        Nothing  -> done []
     (BlockingHead mv elims, _) -> do
       done =<< metaAssign ctx type_ mv elims t2
     (_, BlockingHead mv elims) -> do

--- a/tog.cabal
+++ b/tog.cabal
@@ -109,6 +109,7 @@ library
                      , GADTs
                      , GeneralizedNewtypeDeriving
                      , KindSignatures
+                     , LambdaCase
                      , MultiParamTypeClasses
                      , PatternGuards
                      , RankNTypes


### PR DESCRIPTION
When solving a constraint by spine intersection, the type of the new meta is the same as the type of the old meta. But this should not be the case, because the new meta will be applied to fewer arguments.